### PR TITLE
remove configurable deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Changed GitHub repository to https://github.com/skatkov/webhukhs
 - Testing against rails 7.1, rails 8.0 and rails 8.1
 - Ruby 3.4 used as a default testing target
+- Replaced deprecated `ActiveSupport::Configurable` with `class_attribute`
 
 ## 0.4.2
 

--- a/lib/webhukhs.rb
+++ b/lib/webhukhs.rb
@@ -3,7 +3,7 @@
 require_relative "webhukhs/version"
 require_relative "webhukhs/engine"
 require_relative "webhukhs/jobs/processing_job"
-require "active_support/configurable"
+require "active_support/core_ext/class/attribute"
 
 module Webhukhs
   def self.configuration
@@ -16,10 +16,8 @@ module Webhukhs
 end
 
 class Webhukhs::Configuration
-  include ActiveSupport::Configurable
-
-  config_accessor(:processing_job_class, default: Webhukhs::ProcessingJob)
-  config_accessor(:active_handlers, default: {})
-  config_accessor(:error_context, default: {})
-  config_accessor(:request_body_size_limit, default: 512.kilobytes)
+  class_attribute :processing_job_class, default: Webhukhs::ProcessingJob
+  class_attribute :active_handlers, default: {}
+  class_attribute :error_context, default: {}
+  class_attribute :request_body_size_limit, default: 512.kilobytes
 end


### PR DESCRIPTION
Replace deprecated ActiveSupport::Configurable with class_attribute.

Fix deprecation warning for Rails 8.2 by replacing ActiveSupport::Configurable
with class_attribute.