### PR TITLE
Migrate to ActiveSupport::Notifications

### DIFF
--- a/.github/workflows/mutant.yml
+++ b/.github/workflows/mutant.yml
@@ -1,5 +1,6 @@
 name: mutation tests
-on: [push, pull_request]
+on: [pull_request]
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.yard-lint.yml
+++ b/.yard-lint.yml
@@ -11,12 +11,12 @@ AllValidators:
   # Global file exclusion patterns
   Exclude:
     - '\.git'
-    - 'vendor/**/*'
-    - 'node_modules/**/*'
-    - 'spec/**/*'
-    - 'test/**/*'
-    - 'handler-examples/**/*'
-    - 'example/**/*'
+    - "vendor/**/*"
+    - "node_modules/**/*"
+    - "spec/**/*"
+    - "test/**/*"
+    - "handler-examples/**/*"
+    - "example/**/*"
 
   # Exit code behavior (error, warning, convention, never)
   FailOnSeverity: warning
@@ -32,35 +32,35 @@ AllValidators:
 
 # Documentation validators
 Documentation/UndocumentedObjects:
-  Description: 'Checks for classes, modules, and methods without documentation.'
-  Enabled: true
+  Description: "Checks for classes, modules, and methods without documentation."
+  Enabled: false
   Severity: warning
   ExcludedMethods:
-    - 'initialize/0'  # Exclude parameter-less initialize
-    - '/^_/'          # Exclude private methods (by convention)
+    - "initialize/0" # Exclude parameter-less initialize
+    - "/^_/" # Exclude private methods (by convention)
 
 Documentation/UndocumentedMethodArguments:
-  Description: 'Checks for method parameters without @param tags.'
+  Description: "Checks for method parameters without @param tags."
   Enabled: true
   Severity: warning
 
 Documentation/UndocumentedBooleanMethods:
-  Description: 'Checks that question mark methods document their boolean return.'
+  Description: "Checks that question mark methods document their boolean return."
   Enabled: true
   Severity: warning
 
 Documentation/UndocumentedOptions:
-  Description: 'Detects methods with options hash parameters but no @option tags.'
+  Description: "Detects methods with options hash parameters but no @option tags."
   Enabled: true
   Severity: warning
 
 Documentation/MarkdownSyntax:
-  Description: 'Detects common markdown syntax errors in documentation.'
+  Description: "Detects common markdown syntax errors in documentation."
   Enabled: true
   Severity: warning
 
 Documentation/EmptyCommentLine:
-  Description: 'Detects empty comment lines at the start or end of documentation blocks.'
+  Description: "Detects empty comment lines at the start or end of documentation blocks."
   Enabled: true
   Severity: convention
   EnabledPatterns:
@@ -68,7 +68,7 @@ Documentation/EmptyCommentLine:
     Trailing: true
 
 Documentation/BlankLineBeforeDefinition:
-  Description: 'Detects blank lines between YARD documentation and method definition.'
+  Description: "Detects blank lines between YARD documentation and method definition."
   Enabled: true
   Severity: convention
   OrphanedSeverity: convention
@@ -78,7 +78,7 @@ Documentation/BlankLineBeforeDefinition:
 
 # Tags validators
 Tags/Order:
-  Description: 'Enforces consistent ordering of YARD tags.'
+  Description: "Enforces consistent ordering of YARD tags."
   Enabled: true
   Severity: convention
   EnforcedOrder:
@@ -95,7 +95,7 @@ Tags/Order:
     - todo
 
 Tags/InvalidTypes:
-  Description: 'Validates type definitions in @param, @return, @option tags.'
+  Description: "Validates type definitions in @param, @return, @option tags."
   Enabled: true
   Severity: warning
   ValidatedTags:
@@ -104,7 +104,7 @@ Tags/InvalidTypes:
     - return
 
 Tags/TypeSyntax:
-  Description: 'Validates YARD type syntax using YARD parser.'
+  Description: "Validates YARD type syntax using YARD parser."
   Enabled: true
   Severity: warning
   ValidatedTags:
@@ -114,7 +114,7 @@ Tags/TypeSyntax:
     - yieldreturn
 
 Tags/MeaninglessTag:
-  Description: 'Detects @param/@option tags on classes, modules, or constants.'
+  Description: "Detects @param/@option tags on classes, modules, or constants."
   Enabled: true
   Severity: warning
   CheckedTags:
@@ -126,10 +126,10 @@ Tags/MeaninglessTag:
     - constant
 
 Tags/CollectionType:
-  Description: 'Validates Hash collection syntax consistency.'
+  Description: "Validates Hash collection syntax consistency."
   Enabled: true
   Severity: convention
-  EnforcedStyle: long  # 'long' for Hash{K => V} (YARD standard), 'short' for {K => V}
+  EnforcedStyle: long # 'long' for Hash{K => V} (YARD standard), 'short' for {K => V}
   ValidatedTags:
     - param
     - option
@@ -137,7 +137,7 @@ Tags/CollectionType:
     - yieldreturn
 
 Tags/TagTypePosition:
-  Description: 'Validates type annotation position in tags.'
+  Description: "Validates type annotation position in tags."
   Enabled: true
   Severity: convention
   CheckedTags:
@@ -148,8 +148,8 @@ Tags/TagTypePosition:
   EnforcedStyle: type_after_name
 
 Tags/ApiTags:
-  Description: 'Enforces @api tags on public objects.'
-  Enabled: false  # Opt-in validator
+  Description: "Enforces @api tags on public objects."
+  Enabled: false # Opt-in validator
   Severity: warning
   AllowedApis:
     - public
@@ -157,17 +157,17 @@ Tags/ApiTags:
     - internal
 
 Tags/OptionTags:
-  Description: 'Requires @option tags for methods with options parameters.'
+  Description: "Requires @option tags for methods with options parameters."
   Enabled: true
   Severity: warning
 
 Tags/ExampleSyntax:
-  Description: 'Validates Ruby syntax in @example tags.'
+  Description: "Validates Ruby syntax in @example tags."
   Enabled: true
   Severity: warning
 
 Tags/RedundantParamDescription:
-  Description: 'Detects meaningless parameter descriptions that add no value.'
+  Description: "Detects meaningless parameter descriptions that add no value."
   Enabled: true
   Severity: convention
   CheckedTags:
@@ -204,23 +204,23 @@ Tags/InformalNotation:
   CaseSensitive: false
   RequireStartOfLine: true
   Patterns:
-    Note: '@note'
-    Todo: '@todo'
-    TODO: '@todo'
-    FIXME: '@todo'
-    See: '@see'
-    See also: '@see'
-    Warning: '@deprecated'
-    Deprecated: '@deprecated'
-    Author: '@author'
-    Version: '@version'
-    Since: '@since'
-    Returns: '@return'
-    Raises: '@raise'
-    Example: '@example'
+    Note: "@note"
+    Todo: "@todo"
+    TODO: "@todo"
+    FIXME: "@todo"
+    See: "@see"
+    See also: "@see"
+    Warning: "@deprecated"
+    Deprecated: "@deprecated"
+    Author: "@author"
+    Version: "@version"
+    Since: "@since"
+    Returns: "@return"
+    Raises: "@raise"
+    Example: "@example"
 
 Tags/NonAsciiType:
-  Description: 'Detects non-ASCII characters in type annotations.'
+  Description: "Detects non-ASCII characters in type annotations."
   Enabled: true
   Severity: warning
   ValidatedTags:
@@ -231,8 +231,8 @@ Tags/NonAsciiType:
     - yieldparam
 
 Tags/TagGroupSeparator:
-  Description: 'Enforces blank line separators between different YARD tag groups.'
-  Enabled: false  # Opt-in validator
+  Description: "Enforces blank line separators between different YARD tag groups."
+  Enabled: false # Opt-in validator
   Severity: convention
   TagGroups:
     param: [param, option]
@@ -244,8 +244,8 @@ Tags/TagGroupSeparator:
   RequireAfterDescription: false
 
 Tags/ForbiddenTags:
-  Description: 'Detects forbidden tag and type combinations.'
-  Enabled: false  # Opt-in validator
+  Description: "Detects forbidden tag and type combinations."
+  Enabled: false # Opt-in validator
   Severity: convention
   ForbiddenPatterns: []
   # Example patterns:
@@ -259,37 +259,37 @@ Tags/ForbiddenTags:
 
 # Warnings validators - catches YARD parser errors
 Warnings/UnknownTag:
-  Description: 'Detects unknown YARD tags.'
+  Description: "Detects unknown YARD tags."
   Enabled: true
   Severity: error
 
 Warnings/UnknownDirective:
-  Description: 'Detects unknown YARD directives.'
+  Description: "Detects unknown YARD directives."
   Enabled: true
   Severity: error
 
 Warnings/InvalidTagFormat:
-  Description: 'Detects malformed tag syntax.'
+  Description: "Detects malformed tag syntax."
   Enabled: true
   Severity: error
 
 Warnings/InvalidDirectiveFormat:
-  Description: 'Detects malformed directive syntax.'
+  Description: "Detects malformed directive syntax."
   Enabled: true
   Severity: error
 
 Warnings/DuplicatedParameterName:
-  Description: 'Detects duplicate @param tags.'
+  Description: "Detects duplicate @param tags."
   Enabled: true
   Severity: error
 
 Warnings/UnknownParameterName:
-  Description: 'Detects @param tags for non-existent parameters.'
+  Description: "Detects @param tags for non-existent parameters."
   Enabled: true
   Severity: error
 
 # Semantic validators
 Semantic/AbstractMethods:
-  Description: 'Ensures @abstract methods do not have real implementations.'
+  Description: "Ensures @abstract methods do not have real implementations."
   Enabled: true
   Severity: warning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Changed
 - Emit webhook observability data through `ActiveSupport::Notifications` as a single `webhukhs.event` event instead of logging or reporting errors directly.
-- Generated initializers now include a customizable subscriber that forwards error events to `Rails.error`.
+- Generated initializers now include a commented subscriber example for forwarding error events to `Rails.error`.
 
 ### Removed
 - Removed `config.error_context`; add any custom error reporter context in your notification subscriber instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## Unreleased
 
+### Changed
+- Emit webhook observability data through `ActiveSupport::Notifications` as a single `webhukhs.event` event instead of logging or reporting errors directly.
+- Generated initializers now include a customizable subscriber that forwards error events to `Rails.error`.
+
+### Removed
+- Removed `config.error_context`; add any custom error reporter context in your notification subscriber instead.
+
 ## 0.7.0
 ## Added
 - Codebase is fully mutant tested now and test coverage increased

--- a/README.md
+++ b/README.md
@@ -7,17 +7,29 @@ This is a fork of [cheddar-me/munster](https://github.com/cheddar-me/munster). O
 
 Install the gem and add to the application's Gemfile by executing:
 
-    $ bundle add webhukhs
+```sh
+bundle add webhukhs
+```
 
 If bundler is not being used to manage dependencies, install the gem by executing:
 
-    $ gem install webhukhs
+```sh
+gem install webhukhs
+```
+
+Generate the Webhukhs migrations and initializer:
+
+```sh
+bin/rails g webhukhs:install
+```
+
+This creates database migrations and `config/initializers/webhukhs.rb`. Review the initializer to configure handlers and optional notification subscribers, then run:
+
+```sh
+bin/rails db:migrate
+```
 
 ## Usage
-
-Generate migrations and initializer file.
-
-`bin/rails g webhukhs:install`
 
 Mount webhukhs engine in your routes.
 
@@ -49,7 +61,7 @@ class ExampleHandler < Webhukhs::BaseHandler
 end
 ```
 
-Add the handler to your `webhukhs.rb` config file:
+Add the handler to `config/initializers/webhukhs.rb`:
 
 ```ruby
 Webhukhs.configure do |config|
@@ -76,7 +88,7 @@ This project depends on two dependencies:
 
 Webhukhs emits observability data through a single ActiveSupport notification: `webhukhs.event`.
 
-The generated initializer subscribes to error events and forwards them to [Rails common error reporter](https://guides.rubyonrails.org/error_reporting.html) by default:
+The generated initializer includes a commented example subscriber. Uncomment and adapt it to route events to logs, metrics, error reporters or any other observability system. For Rails 7+ applications, you can forward error events to [Rails common error reporter](https://guides.rubyonrails.org/error_reporting.html):
 
 ```ruby
 ActiveSupport::Notifications.subscribe("webhukhs.event") do |_name, _started, _finished, _id, payload|
@@ -91,7 +103,7 @@ ActiveSupport::Notifications.subscribe("webhukhs.event") do |_name, _started, _f
 end
 ```
 
-You can replace or extend that subscriber to route events to logs, metrics, error reporters or any other observability system. Event payloads include structured non-sensitive metadata when available:
+Event payloads include structured non-sensitive metadata when available:
 
 ```ruby
 {

--- a/README.md
+++ b/README.md
@@ -92,12 +92,11 @@ The generated initializer includes a commented example subscriber. Uncomment and
 
 ```ruby
 ActiveSupport::Notifications.subscribe("webhukhs.event") do |_name, _started, _finished, _id, payload|
-  error = payload[:error]
-  next unless error
+  next unless payload[:severity] == :error
 
   Rails.error.report(
-    error,
-    severity: payload.fetch(:severity, :error),
+    payload.fetch(:error),
+    severity: :error,
     context: payload.except(:error, :severity)
   )
 end

--- a/README.md
+++ b/README.md
@@ -72,16 +72,37 @@ This project depends on two dependencies:
 - Ruby >= 3.0
 - Rails >= 7.0
 
-## Error reporter
+## Notifications
 
-This gem uses [Rails common error reporter](https://guides.rubyonrails.org/error_reporting.html) to report any possible error to services like Honeybadger, Appsignal, Sentry and etc. Most of those services already support this common interface, if not - it's not that hard to add this support on your own.
+Webhukhs emits observability data through a single ActiveSupport notification: `webhukhs.event`.
 
-It's possible to provide additional context for every error. e.g.
+The generated initializer subscribes to error events and forwards them to [Rails common error reporter](https://guides.rubyonrails.org/error_reporting.html) by default:
 
 ```ruby
-Webhukhs.configure do |config|
-  config.error_context = { appsignal: { namespace: "webhooks" } }
+ActiveSupport::Notifications.subscribe("webhukhs.event") do |_name, _started, _finished, _id, payload|
+  error = payload[:error]
+  next unless error
+
+  Rails.error.report(
+    error,
+    severity: payload.fetch(:severity, :error),
+    context: payload.except(:error, :severity)
+  )
 end
+```
+
+You can replace or extend that subscriber to route events to logs, metrics, error reporters or any other observability system. Event payloads include structured non-sensitive metadata when available:
+
+```ruby
+{
+  operation: :receive,
+  outcome: :unknown_handler,
+  severity: :error,
+  error: error,
+  service_id: "stripe",
+  handler_class: "StripeHandler",
+  webhook_id: 123
+}
 ```
 
 ## Development

--- a/lib/webhukhs.rb
+++ b/lib/webhukhs.rb
@@ -8,15 +8,11 @@ require "active_support/notifications"
 
 # Public namespace for Webhukhs runtime and configuration.
 module Webhukhs
-  # Returns singleton configuration object.
-  #
   # @return [Webhukhs::Configuration]
   def self.configuration
     @configuration ||= Configuration.new
   end
 
-  # Yields global configuration object for setup.
-  #
   # @yieldparam configuration [Webhukhs::Configuration]
   # @return [void]
   def self.configure
@@ -28,7 +24,7 @@ module Webhukhs
   # @param payload [Hash] structured event payload
   # @return [void]
   def self.instrument(payload)
-    ActiveSupport::Notifications.instrument("webhukhs.event", payload)
+    ActiveSupport::Notifications.instrument("webhukhs.event", payload.compact)
   end
 end
 

--- a/lib/webhukhs.rb
+++ b/lib/webhukhs.rb
@@ -4,6 +4,7 @@ require_relative "webhukhs/version"
 require_relative "webhukhs/engine"
 require_relative "webhukhs/jobs/processing_job"
 require "active_support/core_ext/class/attribute"
+require "active_support/notifications"
 
 # Public namespace for Webhukhs runtime and configuration.
 module Webhukhs
@@ -21,12 +22,19 @@ module Webhukhs
   def self.configure
     yield configuration
   end
+
+  # Emits Webhukhs observability events.
+  #
+  # @param payload [Hash] structured event payload
+  # @return [void]
+  def self.instrument(payload)
+    ActiveSupport::Notifications.instrument("webhukhs.event", payload)
+  end
 end
 
 # Holds runtime configuration for Webhukhs.
 class Webhukhs::Configuration
   class_attribute :processing_job_class, default: Webhukhs::ProcessingJob
   class_attribute :active_handlers, default: {}
-  class_attribute :error_context, default: {}
   class_attribute :request_body_size_limit, default: 512.kilobytes
 end

--- a/lib/webhukhs/base_handler.rb
+++ b/lib/webhukhs/base_handler.rb
@@ -20,7 +20,7 @@ module Webhukhs
 
       enqueue(webhook)
     rescue ActiveRecord::RecordNotUnique # Webhook deduplicated
-      Rails.logger.info { "#{inspect} Webhook #{handler_event_id} is a duplicate delivery and will not be stored." }
+      Webhukhs.instrument(operation: :receive, outcome: :duplicate, severity: :warn, handler_class: self.class.name)
     end
 
     # Enqueues the processing job to process webhook asynchronously. The job class could be configured.

--- a/lib/webhukhs/base_handler.rb
+++ b/lib/webhukhs/base_handler.rb
@@ -12,7 +12,7 @@ module Webhukhs
     # @param action_dispatch_request [ActionDispatch::Request] request from the controller
     # @return [void]
     def handle(action_dispatch_request)
-      handler_module_name = self.class.name
+      handler_module_name = to_s
       handler_event_id = extract_event_id_from_request(action_dispatch_request)
 
       webhook = ReceivedWebhook.new(request: action_dispatch_request, handler_event_id: handler_event_id, handler_module_name: handler_module_name)
@@ -20,7 +20,14 @@ module Webhukhs
 
       enqueue(webhook)
     rescue ActiveRecord::RecordNotUnique # Webhook deduplicated
-      Webhukhs.instrument(operation: :receive, outcome: :duplicate, severity: :warn, handler_class: self.class.name)
+      Webhukhs.instrument(operation: :receive, outcome: :duplicate, severity: :warn, handler_class: to_s)
+    end
+
+    # Returns a stable handler name for persistence and event payloads.
+    #
+    # @return [String]
+    def to_s
+      self.class.name
     end
 
     # Enqueues the processing job to process webhook asynchronously. The job class could be configured.

--- a/lib/webhukhs/base_handler.rb
+++ b/lib/webhukhs/base_handler.rb
@@ -12,15 +12,18 @@ module Webhukhs
     # @param action_dispatch_request [ActionDispatch::Request] request from the controller
     # @return [void]
     def handle(action_dispatch_request)
-      handler_module_name = to_s
       handler_event_id = extract_event_id_from_request(action_dispatch_request)
 
-      webhook = ReceivedWebhook.new(request: action_dispatch_request, handler_event_id: handler_event_id, handler_module_name: handler_module_name)
+      webhook = ReceivedWebhook.new(
+        request: action_dispatch_request,
+        handler_event_id: handler_event_id,
+        handler_module_name: to_s
+      )
       webhook.save!
 
       enqueue(webhook)
     rescue ActiveRecord::RecordNotUnique # Webhook deduplicated
-      Webhukhs.instrument(operation: :receive, outcome: :duplicate, severity: :warn, handler_class: to_s)
+      Webhukhs.instrument(operation: :receive, outcome: :duplicate, severity: :warn, handler_class: to_s, handler_event_id: handler_event_id)
     end
 
     # Returns a stable handler name for persistence and event payloads.

--- a/lib/webhukhs/base_handler.rb
+++ b/lib/webhukhs/base_handler.rb
@@ -12,24 +12,25 @@ module Webhukhs
     # @param action_dispatch_request [ActionDispatch::Request] request from the controller
     # @return [void]
     def handle(action_dispatch_request)
+      module_name = handler_module_name
       handler_event_id = extract_event_id_from_request(action_dispatch_request)
 
       webhook = ReceivedWebhook.new(
         request: action_dispatch_request,
         handler_event_id: handler_event_id,
-        handler_module_name: to_s
+        handler_module_name: module_name
       )
       webhook.save!
 
       enqueue(webhook)
     rescue ActiveRecord::RecordNotUnique # Webhook deduplicated
-      Webhukhs.instrument(operation: :receive, outcome: :duplicate, severity: :warn, handler_class: to_s, handler_event_id: handler_event_id)
+      Webhukhs.instrument(operation: :receive, outcome: :duplicate, severity: :warn, handler_class: module_name, handler_event_id: handler_event_id)
     end
 
-    # Returns a stable handler name for persistence and event payloads.
+    # Returns the module name used for persistence and event payloads.
     #
     # @return [String]
-    def to_s
+    def handler_module_name
       self.class.name
     end
 

--- a/lib/webhukhs/controllers/receive_webhooks_controller.rb
+++ b/lib/webhukhs/controllers/receive_webhooks_controller.rb
@@ -17,18 +17,23 @@ module Webhukhs
     def create
       handler = lookup_handler(service_id)
       raise HandlerInactive unless handler.active?
+
       handler.handle(request)
+
       render(json: {ok: true, error: nil})
     rescue UnknownHandler => e
       Webhukhs.instrument(operation: :receive, outcome: :unknown_handler, severity: :error, error: e, service_id: service_id)
       render_error_with_status("No handler found for #{service_id.inspect}", status: :not_found)
     rescue HandlerInactive => e
-      Webhukhs.instrument(operation: :receive, outcome: :inactive_handler, severity: :error, error: e, service_id: service_id, handler_class: handler.to_s)
+      Webhukhs.instrument(
+        operation: :receive, outcome: :inactive_handler, severity: :error, error: e, service_id: service_id, handler_class: handler.to_s
+      )
       render_error_with_status("Webhook handler #{service_id.inspect} is inactive", status: :service_unavailable)
     rescue => e
-      event = {operation: :receive, outcome: :error, severity: :error, error: e, service_id: service_id}
-      event[:handler_class] = handler.to_s if handler
-      Webhukhs.instrument(event)
+      Webhukhs.instrument(
+        {operation: :receive, outcome: :error, severity: :error, error: e, service_id: service_id, handler_class: handler&.to_s}
+      )
+
       raise unless handler
       raise if handler.expose_errors_to_sender?
       render_error_with_status("Internal error (#{e})")

--- a/lib/webhukhs/controllers/receive_webhooks_controller.rb
+++ b/lib/webhukhs/controllers/receive_webhooks_controller.rb
@@ -15,21 +15,22 @@ module Webhukhs
     #
     # @return [void]
     def create
-      Rails.error.set_context(**Webhukhs.configuration.error_context)
       handler = lookup_handler(service_id)
       raise HandlerInactive unless handler.active?
       handler.handle(request)
       render(json: {ok: true, error: nil})
     rescue UnknownHandler => e
-      Rails.error.report(e, severity: :error)
+      Webhukhs.instrument(operation: :receive, outcome: :unknown_handler, severity: :error, error: e, service_id: service_id)
       render_error_with_status("No handler found for #{service_id.inspect}", status: :not_found)
     rescue HandlerInactive => e
-      Rails.error.report(e, severity: :error)
+      Webhukhs.instrument(operation: :receive, outcome: :inactive_handler, severity: :error, error: e, service_id: service_id, handler_class: handler.class.name)
       render_error_with_status("Webhook handler #{service_id.inspect} is inactive", status: :service_unavailable)
     rescue => e
+      event = {operation: :receive, outcome: :error, severity: :error, error: e, service_id: service_id}
+      event[:handler_class] = handler.class.name if handler
+      Webhukhs.instrument(event)
       raise unless handler
       raise if handler.expose_errors_to_sender?
-      Rails.error.report(e, severity: :error)
       render_error_with_status("Internal error (#{e})")
     end
 

--- a/lib/webhukhs/controllers/receive_webhooks_controller.rb
+++ b/lib/webhukhs/controllers/receive_webhooks_controller.rb
@@ -23,11 +23,11 @@ module Webhukhs
       Webhukhs.instrument(operation: :receive, outcome: :unknown_handler, severity: :error, error: e, service_id: service_id)
       render_error_with_status("No handler found for #{service_id.inspect}", status: :not_found)
     rescue HandlerInactive => e
-      Webhukhs.instrument(operation: :receive, outcome: :inactive_handler, severity: :error, error: e, service_id: service_id, handler_class: handler.class.name)
+      Webhukhs.instrument(operation: :receive, outcome: :inactive_handler, severity: :error, error: e, service_id: service_id, handler_class: handler.to_s)
       render_error_with_status("Webhook handler #{service_id.inspect} is inactive", status: :service_unavailable)
     rescue => e
       event = {operation: :receive, outcome: :error, severity: :error, error: e, service_id: service_id}
-      event[:handler_class] = handler.class.name if handler
+      event[:handler_class] = handler.to_s if handler
       Webhukhs.instrument(event)
       raise unless handler
       raise if handler.expose_errors_to_sender?

--- a/lib/webhukhs/controllers/receive_webhooks_controller.rb
+++ b/lib/webhukhs/controllers/receive_webhooks_controller.rb
@@ -31,7 +31,7 @@ module Webhukhs
       render_error_with_status("Webhook handler #{service_id.inspect} is inactive", status: :service_unavailable)
     rescue => e
       Webhukhs.instrument(
-        {operation: :receive, outcome: :error, severity: :error, error: e, service_id: service_id, handler_class: handler&.to_s}
+        operation: :receive, outcome: :error, severity: :error, error: e, service_id: service_id, handler_class: handler&.to_s
       )
 
       raise unless handler

--- a/lib/webhukhs/controllers/receive_webhooks_controller.rb
+++ b/lib/webhukhs/controllers/receive_webhooks_controller.rb
@@ -23,15 +23,17 @@ module Webhukhs
       render(json: {ok: true, error: nil})
     rescue UnknownHandler => e
       Webhukhs.instrument(operation: :receive, outcome: :unknown_handler, severity: :error, error: e, service_id: service_id)
+
       render_error_with_status("No handler found for #{service_id.inspect}", status: :not_found)
     rescue HandlerInactive => e
       Webhukhs.instrument(
-        operation: :receive, outcome: :inactive_handler, severity: :error, error: e, service_id: service_id, handler_class: handler.to_s
+        operation: :receive, outcome: :inactive_handler, severity: :error, error: e, service_id: service_id, handler_class: handler.handler_module_name
       )
+
       render_error_with_status("Webhook handler #{service_id.inspect} is inactive", status: :service_unavailable)
     rescue => e
       Webhukhs.instrument(
-        operation: :receive, outcome: :error, severity: :error, error: e, service_id: service_id, handler_class: handler&.to_s
+        operation: :receive, outcome: :error, severity: :error, error: e, service_id: service_id, handler_class: handler&.handler_module_name
       )
 
       raise unless handler

--- a/lib/webhukhs/jobs/processing_job.rb
+++ b/lib/webhukhs/jobs/processing_job.rb
@@ -3,17 +3,13 @@
 require "active_job/railtie"
 
 module Webhukhs
-  # Background job that validates and processes a persisted webhook.
   class ProcessingJob < ActiveJob::Base
-    # Raised when the job receives an invalid webhook argument.
     class InvalidWebhookArgument < StandardError; end
 
     discard_on ActiveJob::DeserializationError, InvalidWebhookArgument do |_job, error|
       Webhukhs.instrument(operation: :process, outcome: :discarded, severity: :error, error: error)
     end
 
-    # Runs webhook validation and processing lifecycle.
-    #
     # @param webhook [Webhukhs::ReceivedWebhook] webhook record to process
     # @return [void]
     def perform(webhook)

--- a/lib/webhukhs/jobs/processing_job.rb
+++ b/lib/webhukhs/jobs/processing_job.rb
@@ -18,9 +18,11 @@ module Webhukhs
         raise InvalidWebhookArgument, "ProcessingJob expected Webhukhs::ReceivedWebhook, got #{webhook.class}"
       end
 
+      event = {operation: :process, severity: :info, webhook_id: webhook.id, handler_class: webhook.handler_module_name}
+
       webhook.with_lock do
         unless webhook.received?
-          Webhukhs.instrument(operation: :process, outcome: :skipped, severity: :info, webhook_id: webhook.id, handler_class: webhook.handler_module_name)
+          Webhukhs.instrument(event.merge(outcome: :skipped))
           return
         end
 
@@ -28,18 +30,18 @@ module Webhukhs
       end
 
       if webhook.handler.valid?(webhook.request)
-        Webhukhs.instrument(operation: :process, outcome: :started, severity: :info, webhook_id: webhook.id, handler_class: webhook.handler_module_name)
+        Webhukhs.instrument(**event.merge(outcome: :started))
         webhook.handler.process(webhook)
         webhook.processed! if webhook.processing?
-        Webhukhs.instrument(operation: :process, outcome: :completed, severity: :info, webhook_id: webhook.id, handler_class: webhook.handler_module_name)
+        Webhukhs.instrument(**event.merge(outcome: :completed))
       else
-        Webhukhs.instrument(operation: :process, outcome: :validation_failed, severity: :info, webhook_id: webhook.id, handler_class: webhook.handler_module_name)
+        Webhukhs.instrument(**event.merge(outcome: :validation_failed))
         webhook.failed_validation!
       end
     rescue => error
       if webhook.respond_to?(:error!)
         webhook.error!
-        Webhukhs.instrument(operation: :process, outcome: :error, severity: :error, error: error, webhook_id: webhook.id, handler_class: webhook.handler_module_name)
+        Webhukhs.instrument(**event.merge(outcome: :error, severity: :error, error: error))
       end
       raise
     end

--- a/lib/webhukhs/jobs/processing_job.rb
+++ b/lib/webhukhs/jobs/processing_job.rb
@@ -8,11 +8,8 @@ module Webhukhs
     # Raised when the job receives an invalid webhook argument.
     class InvalidWebhookArgument < StandardError; end
 
-    discard_on ActiveJob::DeserializationError, InvalidWebhookArgument do |job, error|
-      Rails.error.report(error, context: {
-        job_id: job.job_id,
-        arguments: job.arguments.map(&:inspect)
-      }, severity: :error)
+    discard_on ActiveJob::DeserializationError, InvalidWebhookArgument do |_job, error|
+      Webhukhs.instrument(operation: :process, outcome: :discarded, severity: :error, error: error)
     end
 
     # Runs webhook validation and processing lifecycle.
@@ -25,11 +22,9 @@ module Webhukhs
         raise InvalidWebhookArgument, "ProcessingJob expected Webhukhs::ReceivedWebhook, got #{webhook.class}"
       end
 
-      webhook_details_for_logs = "Webhukhs::ReceivedWebhook#%s (handler: %s)" % [webhook.id, webhook.handler]
-
       webhook.with_lock do
         unless webhook.received?
-          logger.info { "#{webhook_details_for_logs} is being processed in a different job or has been processed already, skipping." }
+          Webhukhs.instrument(operation: :process, outcome: :skipped, severity: :info, webhook_id: webhook.id, handler_class: webhook.handler_module_name)
           return
         end
 
@@ -37,16 +32,19 @@ module Webhukhs
       end
 
       if webhook.handler.valid?(webhook.request)
-        logger.info { "#{webhook_details_for_logs} starting to process" }
+        Webhukhs.instrument(operation: :process, outcome: :started, severity: :info, webhook_id: webhook.id, handler_class: webhook.handler_module_name)
         webhook.handler.process(webhook)
         webhook.processed! if webhook.processing?
-        logger.info { "#{webhook_details_for_logs} processed" }
+        Webhukhs.instrument(operation: :process, outcome: :completed, severity: :info, webhook_id: webhook.id, handler_class: webhook.handler_module_name)
       else
-        logger.info { "#{webhook_details_for_logs} did not pass validation by the handler. Marking it `failed_validation`." }
+        Webhukhs.instrument(operation: :process, outcome: :validation_failed, severity: :info, webhook_id: webhook.id, handler_class: webhook.handler_module_name)
         webhook.failed_validation!
       end
-    rescue
-      webhook.error! if webhook.respond_to?(:error!)
+    rescue => error
+      if webhook.respond_to?(:error!)
+        webhook.error!
+        Webhukhs.instrument(operation: :process, outcome: :error, severity: :error, error: error, webhook_id: webhook.id, handler_class: webhook.handler_module_name)
+      end
       raise
     end
   end

--- a/lib/webhukhs/models/received_webhook.rb
+++ b/lib/webhukhs/models/received_webhook.rb
@@ -106,7 +106,7 @@ module Webhukhs
 
     private
 
-    # Assigns a generated id when database does not auto-increment ids.
+    # Assigns UUID when database does not auto-increment ids.
     #
     # @return [void]
     def ensure_id

--- a/lib/webhukhs/templates/webhukhs.rb
+++ b/lib/webhukhs/templates/webhukhs.rb
@@ -24,17 +24,24 @@ Webhukhs.configure do |config|
   #
   # config.processing_job_class = "WebhookProcessingJob"
 
-  # We're using a common interface for error reporting provided by Rails, e.g Rails.error.report. In some cases
-  # you want to enhance those errors with additional context. As example to provide a namespace:
-  #
-  # { appsignal: { namespace: "webhooks" } }
-  #
-  # config.error_context = { appsignal: { namespace: "webhooks" } }
-
   # Incoming webhooks will be written into your DB without any prior validation. By default, Webhukhs limits the
   # request body size for webhooks to 512 KiB, so that it would not be too easy for an attacker to fill your
   # database with junk. However, if you are receiving very large webhook payloads you might need to increase
   # that limit (or make it even smaller for extra security)
   #
   # config.request_body_size_limit = 2.megabytes
+end
+
+# Webhukhs emits all observability data through a single ActiveSupport::Notifications event.
+# Error events are forwarded to Rails.error by default. You can customize this subscriber to
+# route events to logs, metrics, error reporters or any other observability system.
+ActiveSupport::Notifications.subscribe("webhukhs.event") do |_name, _started, _finished, _id, payload|
+  error = payload[:error]
+  next unless error
+
+  Rails.error.report(
+    error,
+    severity: payload.fetch(:severity, :error),
+    context: payload.except(:error, :severity)
+  )
 end

--- a/lib/webhukhs/templates/webhukhs.rb
+++ b/lib/webhukhs/templates/webhukhs.rb
@@ -36,12 +36,11 @@ end
 # Subscribe to route events to logs, metrics, error reporters or any other observability system.
 #
 # ActiveSupport::Notifications.subscribe("webhukhs.event") do |_name, _started, _finished, _id, payload|
-#   error = payload[:error]
-#   next unless error
+#   next unless payload[:severity] == :error
 #
 #   Rails.error.report(
-#     error,
-#     severity: payload.fetch(:severity, :error),
+#     payload.fetch(:error),
+#     severity: :error,
 #     context: payload.except(:error, :severity)
 #   )
 # end

--- a/lib/webhukhs/templates/webhukhs.rb
+++ b/lib/webhukhs/templates/webhukhs.rb
@@ -33,15 +33,15 @@ Webhukhs.configure do |config|
 end
 
 # Webhukhs emits all observability data through a single ActiveSupport::Notifications event.
-# Error events are forwarded to Rails.error by default. You can customize this subscriber to
-# route events to logs, metrics, error reporters or any other observability system.
-ActiveSupport::Notifications.subscribe("webhukhs.event") do |_name, _started, _finished, _id, payload|
-  error = payload[:error]
-  next unless error
-
-  Rails.error.report(
-    error,
-    severity: payload.fetch(:severity, :error),
-    context: payload.except(:error, :severity)
-  )
-end
+# Subscribe to route events to logs, metrics, error reporters or any other observability system.
+#
+# ActiveSupport::Notifications.subscribe("webhukhs.event") do |_name, _started, _finished, _id, payload|
+#   error = payload[:error]
+#   next unless error
+#
+#   Rails.error.report(
+#     error,
+#     severity: payload.fetch(:severity, :error),
+#     context: payload.except(:error, :severity)
+#   )
+# end

--- a/lib/webhukhs/templates/webhukhs.rb
+++ b/lib/webhukhs/templates/webhukhs.rb
@@ -34,6 +34,19 @@ end
 
 # Webhukhs emits all observability data through a single ActiveSupport::Notifications event.
 # Subscribe to route events to logs, metrics, error reporters or any other observability system.
+#
+# @example schema for event payload
+# {
+#   operation: :receive | :process,
+#   outcome: :duplicate | :unknown_handler | :inactive_handler | :error |
+#            :discarded | :skipped | :started | :completed | :validation_failed,
+#   severity: :info | :warn | :error,
+#   error: Exception,             # only present for error events
+#   service_id: String,           # optional
+#   handler_class: String,        # optional
+#   handler_event_id: String,     # optional
+#   webhook_id: Integer | String  # optional
+# }
 ActiveSupport::Notifications.subscribe("webhukhs.event") do |_name, _started, _finished, _id, payload|
   next unless payload[:severity] == :error
 

--- a/lib/webhukhs/templates/webhukhs.rb
+++ b/lib/webhukhs/templates/webhukhs.rb
@@ -34,13 +34,12 @@ end
 
 # Webhukhs emits all observability data through a single ActiveSupport::Notifications event.
 # Subscribe to route events to logs, metrics, error reporters or any other observability system.
-#
-# ActiveSupport::Notifications.subscribe("webhukhs.event") do |_name, _started, _finished, _id, payload|
-#   next unless payload[:severity] == :error
-#
-#   Rails.error.report(
-#     payload.fetch(:error),
-#     severity: :error,
-#     context: payload.except(:error, :severity)
-#   )
-# end
+ActiveSupport::Notifications.subscribe("webhukhs.event") do |_name, _started, _finished, _id, payload|
+  next unless payload[:severity] == :error
+
+  Rails.error.report(
+    payload.fetch(:error),
+    severity: :error,
+    context: payload.except(:error, :severity)
+  )
+end

--- a/test/base_handler_test.rb
+++ b/test/base_handler_test.rb
@@ -96,7 +96,7 @@ class BaseHandlerTest < ActiveSupport::TestCase
     assert_equal :duplicate, event.fetch(:outcome)
     assert_equal :warn, event.fetch(:severity)
     assert_equal "ExtractIdHandler", event.fetch(:handler_class)
-    assert_false event.key?(:handler_event_id)
+    assert_equal "duplicate-event", event.fetch(:handler_event_id)
   end
 
   test "enqueue uses configured processing job classes directly" do

--- a/test/base_handler_test.rb
+++ b/test/base_handler_test.rb
@@ -73,7 +73,7 @@ class BaseHandlerTest < ActiveSupport::TestCase
     end
   end
 
-  test "handle logs duplicate deliveries" do
+  test "handle emits duplicate delivery events" do
     handler = ExtractIdHandler.new
     request_headers = {
       "CONTENT_TYPE" => "application/json",
@@ -86,11 +86,17 @@ class BaseHandlerTest < ActiveSupport::TestCase
 
     handler.handle(first_request)
 
-    with_captured_info_logs(Rails) do |messages|
+    events = captured_webhukhs_events do
       handler.handle(second_request)
-
-      assert_equal ["#{handler.inspect} Webhook duplicate-event is a duplicate delivery and will not be stored."], messages
     end
+
+    assert_equal 1, events.size
+    event = events.fetch(0)
+    assert_equal :receive, event.fetch(:operation)
+    assert_equal :duplicate, event.fetch(:outcome)
+    assert_equal :warn, event.fetch(:severity)
+    assert_equal "ExtractIdHandler", event.fetch(:handler_class)
+    assert_false event.key?(:handler_event_id)
   end
 
   test "enqueue uses configured processing job classes directly" do

--- a/test/base_handler_test.rb
+++ b/test/base_handler_test.rb
@@ -15,9 +15,15 @@ end
 class HandleProbeHandler < Webhukhs::BaseHandler
   attr_reader :enqueued_webhook
 
+  def to_s = "custom handler string"
+
   def enqueue(webhook)
     @enqueued_webhook = webhook
   end
+end
+
+class CustomStringExtractIdHandler < ExtractIdHandler
+  def to_s = "custom extract id handler string"
 end
 
 class BaseHandlerTest < ActiveSupport::TestCase
@@ -48,7 +54,7 @@ class BaseHandlerTest < ActiveSupport::TestCase
     refute_equal first_id, second_id
   end
 
-  test "handle passes the handler class name into received webhooks" do
+  test "handle passes the handler module name into received webhooks" do
     captured_attributes = nil
     request = ActionDispatch::Request.new(
       "rack.input" => StringIO.new("{}"),
@@ -74,7 +80,7 @@ class BaseHandlerTest < ActiveSupport::TestCase
   end
 
   test "handle emits duplicate delivery events" do
-    handler = ExtractIdHandler.new
+    handler = CustomStringExtractIdHandler.new
     request_headers = {
       "CONTENT_TYPE" => "application/json",
       "action_dispatch.request.path_parameters" => {}
@@ -95,7 +101,7 @@ class BaseHandlerTest < ActiveSupport::TestCase
     assert_equal :receive, event.fetch(:operation)
     assert_equal :duplicate, event.fetch(:outcome)
     assert_equal :warn, event.fetch(:severity)
-    assert_equal "ExtractIdHandler", event.fetch(:handler_class)
+    assert_equal "CustomStringExtractIdHandler", event.fetch(:handler_class)
     assert_equal "duplicate-event", event.fetch(:handler_event_id)
   end
 

--- a/test/processing_job_test.rb
+++ b/test/processing_job_test.rb
@@ -38,10 +38,18 @@ class ProcessingJobTest < ActiveJob::TestCase
   end
 
   test "discards job and reports invalid webhook arguments" do
-    [nil, "not a webhook"].each do |argument|
-      assert_error_reported(Webhukhs::ProcessingJob::InvalidWebhookArgument) do
+    events = captured_webhukhs_events do
+      [nil, "not a webhook"].each do |argument|
         Webhukhs::ProcessingJob.perform_now(argument)
       end
+    end
+
+    assert_equal 2, events.size
+    events.each do |event|
+      assert_equal :process, event.fetch(:operation)
+      assert_equal :discarded, event.fetch(:outcome)
+      assert_equal :error, event.fetch(:severity)
+      assert_instance_of Webhukhs::ProcessingJob::InvalidWebhookArgument, event.fetch(:error)
     end
   end
 
@@ -82,7 +90,7 @@ class ProcessingJobTest < ActiveJob::TestCase
     assert_predicate webhook.reload, :failed_validation?
   end
 
-  test "logs when processing is skipped because the webhook is not received" do
+  test "emits event when processing is skipped because the webhook is not received" do
     webhook = Webhukhs::ReceivedWebhook.create!(
       handler_event_id: "skip-log-test",
       handler_module_name: "LoggingHandler",
@@ -91,16 +99,21 @@ class ProcessingJobTest < ActiveJob::TestCase
       request_headers: {}
     )
     job = Webhukhs::ProcessingJob.new
-    details = "Webhukhs::ReceivedWebhook##{webhook.id} (handler: LoggingHandler)"
 
-    with_captured_info_logs(Webhukhs::ProcessingJob) do |messages|
+    events = captured_webhukhs_events do
       job.perform(webhook)
-
-      assert_equal ["#{details} is being processed in a different job or has been processed already, skipping."], messages
     end
+
+    assert_equal 1, events.size
+    event = events.fetch(0)
+    assert_equal :process, event.fetch(:operation)
+    assert_equal :skipped, event.fetch(:outcome)
+    assert_equal :info, event.fetch(:severity)
+    assert_equal webhook.id, event.fetch(:webhook_id)
+    assert_equal "LoggingHandler", event.fetch(:handler_class)
   end
 
-  test "logs when processing starts and completes" do
+  test "emits events when processing starts and completes" do
     webhook = Webhukhs::ReceivedWebhook.create!(
       handler_event_id: "success-log-test",
       handler_module_name: "LoggingHandler",
@@ -112,19 +125,24 @@ class ProcessingJobTest < ActiveJob::TestCase
       }
     )
     job = Webhukhs::ProcessingJob.new
-    details = "Webhukhs::ReceivedWebhook##{webhook.id} (handler: LoggingHandler)"
 
-    with_captured_info_logs(Webhukhs::ProcessingJob) do |messages|
+    events = captured_webhukhs_events do
       job.perform(webhook)
+    end
 
-      assert_equal ["#{details} starting to process", "#{details} processed"], messages
+    assert_equal [:started, :completed], events.map { |event| event.fetch(:outcome) }
+    events.each do |event|
+      assert_equal :process, event.fetch(:operation)
+      assert_equal :info, event.fetch(:severity)
+      assert_equal webhook.id, event.fetch(:webhook_id)
+      assert_equal "LoggingHandler", event.fetch(:handler_class)
     end
 
     assert_predicate webhook.reload, :processed?
     assert_equal [webhook.id], LoggingHandler.processed_webhook_ids
   end
 
-  test "logs when validation fails" do
+  test "emits event when validation fails" do
     webhook = Webhukhs::ReceivedWebhook.create!(
       handler_event_id: "failed-validation-log-test",
       handler_module_name: "InvalidLoggingHandler",
@@ -136,13 +154,18 @@ class ProcessingJobTest < ActiveJob::TestCase
       }
     )
     job = Webhukhs::ProcessingJob.new
-    details = "Webhukhs::ReceivedWebhook##{webhook.id} (handler: InvalidLoggingHandler)"
 
-    with_captured_info_logs(Webhukhs::ProcessingJob) do |messages|
+    events = captured_webhukhs_events do
       job.perform(webhook)
-
-      assert_equal ["#{details} did not pass validation by the handler. Marking it `failed_validation`."], messages
     end
+
+    assert_equal 1, events.size
+    event = events.fetch(0)
+    assert_equal :process, event.fetch(:operation)
+    assert_equal :validation_failed, event.fetch(:outcome)
+    assert_equal :info, event.fetch(:severity)
+    assert_equal webhook.id, event.fetch(:webhook_id)
+    assert_equal "InvalidLoggingHandler", event.fetch(:handler_class)
 
     assert_predicate webhook.reload, :failed_validation?
   end
@@ -175,8 +198,15 @@ class ProcessingJobTest < ActiveJob::TestCase
     Webhukhs::ProcessingJob.perform_later(webhook)
     webhook.destroy!
 
-    assert_error_reported(ActiveJob::DeserializationError) do
+    events = captured_webhukhs_events do
       perform_enqueued_jobs
     end
+
+    assert_equal 1, events.size
+    event = events.fetch(0)
+    assert_equal :process, event.fetch(:operation)
+    assert_equal :discarded, event.fetch(:outcome)
+    assert_equal :error, event.fetch(:severity)
+    assert_instance_of ActiveJob::DeserializationError, event.fetch(:error)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -68,20 +68,17 @@ class ActiveSupport::TestCase
     with_overridden_singleton_methods(target, {method_name => implementation}, &block)
   end
 
-  def with_captured_info_logs(logger_owner)
-    messages = []
-    original_logger = logger_owner.logger
-    test_logger = ActiveSupport::Logger.new(StringIO.new)
-    test_logger.level = Logger::INFO
-    test_logger.formatter = lambda do |_severity, _time, _progname, message|
-      messages << message
-      ""
+  def captured_webhukhs_events
+    events = []
+    subscriber = lambda do |*args|
+      events << ActiveSupport::Notifications::Event.new(*args).payload
     end
 
-    logger_owner.logger = test_logger
-    yield messages
-  ensure
-    logger_owner.logger = original_logger
+    ActiveSupport::Notifications.subscribed(subscriber, "webhukhs.event") do
+      yield
+    end
+
+    events
   end
 
   def with_overridden_singleton_methods(target, methods)

--- a/test/webhukhs_test.rb
+++ b/test/webhukhs_test.rb
@@ -77,15 +77,6 @@ class TestWebhukhs < ActionDispatch::IntegrationTest
     assert_nothing_raised { Webhukhs::Engine.load_generators }
   end
 
-  test "generated initializer subscribes error events to Rails error reporter" do
-    initializer_template = File.read(File.expand_path("../lib/webhukhs/templates/webhukhs.rb", __dir__))
-
-    assert_includes initializer_template, 'ActiveSupport::Notifications.subscribe("webhukhs.event")'
-    assert_includes initializer_template, "Rails.error.report"
-    assert_includes initializer_template, "payload.fetch(:severity, :error)"
-    refute_includes initializer_template, "error_context"
-  end
-
   test "accepts a webhook, stores and processes it" do
     tf = Tempfile.new
     body = {isValid: true, outputToFilename: tf.path}

--- a/test/webhukhs_test.rb
+++ b/test/webhukhs_test.rb
@@ -68,11 +68,6 @@ class TestWebhukhs < ActionDispatch::IntegrationTest
     assert_equal [{operation: :receive, outcome: :accepted, severity: :info}], events
   end
 
-  test "configuration does not include error context" do
-    assert_false Webhukhs.configuration.respond_to?(:error_context)
-    assert_false Webhukhs.configuration.respond_to?(:error_context=)
-  end
-
   test "loads engine generators" do
     assert_nothing_raised { Webhukhs::Engine.load_generators }
   end

--- a/test/webhukhs_test.rb
+++ b/test/webhukhs_test.rb
@@ -60,8 +60,30 @@ class TestWebhukhs < ActionDispatch::IntegrationTest
     Webhukhs.instance_variable_set(:@configuration, original_configuration)
   end
 
+  test "emits single structured webhukhs event notifications" do
+    events = captured_webhukhs_events do
+      Webhukhs.instrument(operation: :receive, outcome: :accepted, severity: :info)
+    end
+
+    assert_equal [{operation: :receive, outcome: :accepted, severity: :info}], events
+  end
+
+  test "configuration does not include error context" do
+    assert_false Webhukhs.configuration.respond_to?(:error_context)
+    assert_false Webhukhs.configuration.respond_to?(:error_context=)
+  end
+
   test "loads engine generators" do
     assert_nothing_raised { Webhukhs::Engine.load_generators }
+  end
+
+  test "generated initializer subscribes error events to Rails error reporter" do
+    initializer_template = File.read(File.expand_path("../lib/webhukhs/templates/webhukhs.rb", __dir__))
+
+    assert_includes initializer_template, 'ActiveSupport::Notifications.subscribe("webhukhs.event")'
+    assert_includes initializer_template, "Rails.error.report"
+    assert_includes initializer_template, "payload.fetch(:severity, :error)"
+    refute_includes initializer_template, "error_context"
   end
 
   test "accepts a webhook, stores and processes it" do
@@ -108,7 +130,17 @@ class TestWebhukhs < ActionDispatch::IntegrationTest
 
     webhook = Webhukhs::ReceivedWebhook.last!
 
-    assert_raises(StandardError) { perform_enqueued_jobs }
+    events = captured_webhukhs_events do
+      assert_raises(StandardError) { perform_enqueued_jobs }
+    end
+
+    assert_equal [:started, :error], events.map { |event| event.fetch(:outcome) }
+    error_event = events.fetch(1)
+    assert_equal :process, error_event.fetch(:operation)
+    assert_equal :error, error_event.fetch(:severity)
+    assert_equal webhook.id, error_event.fetch(:webhook_id)
+    assert_equal "WebhookTestHandler", error_event.fetch(:handler_class)
+    assert_instance_of RuntimeError, error_event.fetch(:error)
     assert_predicate webhook.reload, :error?
 
     tf.rewind
@@ -144,34 +176,42 @@ class TestWebhukhs < ActionDispatch::IntegrationTest
   end
 
   test "raises an error if the service_id is not known" do
-    report = assert_error_reported(Webhukhs::ReceiveWebhooksController::UnknownHandler) do
+    events = captured_webhukhs_events do
       post "/webhukhs/missing_service", params: webhook_body, headers: {"CONTENT_TYPE" => "application/json"}
 
       assert_response 404
       assert_equal "No handler found for \"missing_service\"", response.parsed_body["error"]
     end
 
-    assert_predicate report, :handled?
-    assert_equal :error, report.severity
+    assert_equal 1, events.size
+    event = events.fetch(0)
+    assert_equal :receive, event.fetch(:operation)
+    assert_equal :unknown_handler, event.fetch(:outcome)
+    assert_equal :error, event.fetch(:severity)
+    assert_equal "missing_service", event.fetch(:service_id)
+    assert_instance_of Webhukhs::ReceiveWebhooksController::UnknownHandler, event.fetch(:error)
   end
 
   test "returns a 503 when a handler is inactive" do
-    report = assert_error_reported(Webhukhs::ReceiveWebhooksController::HandlerInactive) do
+    events = captured_webhukhs_events do
       post "/webhukhs/inactive", params: webhook_body, headers: {"CONTENT_TYPE" => "application/json"}
 
       assert_response 503
       assert_equal 'Webhook handler "inactive" is inactive', response.parsed_body["error"]
     end
 
-    assert_predicate report, :handled?
-    assert_equal :error, report.severity
+    assert_equal 1, events.size
+    event = events.fetch(0)
+    assert_equal :receive, event.fetch(:operation)
+    assert_equal :inactive_handler, event.fetch(:outcome)
+    assert_equal :error, event.fetch(:severity)
+    assert_equal "inactive", event.fetch(:service_id)
+    assert_equal "InactiveHandler", event.fetch(:handler_class)
+    assert_instance_of Webhukhs::ReceiveWebhooksController::HandlerInactive, event.fetch(:error)
   end
 
   test "returns a 200 status and error message if the handler does not expose errors" do
-    original_error_context = Webhukhs.configuration.error_context
-    Webhukhs.configuration.error_context = {component: "webhooks"}
-
-    report = assert_error_reported(RuntimeError) do
+    events = captured_webhukhs_events do
       post "/webhukhs/failing-with-concealed-errors", params: webhook_body, headers: {"CONTENT_TYPE" => "application/json"}
 
       assert_response 200
@@ -179,17 +219,30 @@ class TestWebhukhs < ActionDispatch::IntegrationTest
       assert_equal "Internal error (oops)", response.parsed_body["error"]
     end
 
-    assert_predicate report, :handled?
-    assert_equal :error, report.severity
-    assert_equal "webhooks", report.context[:component]
-  ensure
-    Webhukhs.configuration.error_context = original_error_context
+    assert_equal 1, events.size
+    event = events.fetch(0)
+    assert_equal :receive, event.fetch(:operation)
+    assert_equal :error, event.fetch(:outcome)
+    assert_equal :error, event.fetch(:severity)
+    assert_equal "failing-with-concealed-errors", event.fetch(:service_id)
+    assert_equal "FailingWithConcealedErrors", event.fetch(:handler_class)
+    assert_instance_of RuntimeError, event.fetch(:error)
   end
 
   test "returns a 500 status and error message if the handler does not expose errors" do
-    post "/webhukhs/failing-with-exposed-errors", params: webhook_body, headers: {"CONTENT_TYPE" => "application/json"}
+    events = captured_webhukhs_events do
+      post "/webhukhs/failing-with-exposed-errors", params: webhook_body, headers: {"CONTENT_TYPE" => "application/json"}
+    end
 
     assert_response 500
+    assert_equal 1, events.size
+    event = events.fetch(0)
+    assert_equal :receive, event.fetch(:operation)
+    assert_equal :error, event.fetch(:outcome)
+    assert_equal :error, event.fetch(:severity)
+    assert_equal "failing-with-exposed-errors", event.fetch(:service_id)
+    assert_equal "FailingWithExposedErrors", event.fetch(:handler_class)
+    assert_instance_of RuntimeError, event.fetch(:error)
     # The response generation in this case is done by Rails, through the
     # common Rails error page
   end
@@ -211,9 +264,20 @@ class TestWebhukhs < ActionDispatch::IntegrationTest
     original_error = NameError.new("uninitialized constant MissingHandler")
     controller = FailingLookupReceiveWebhooksController.new(original_error)
 
-    raised_error = assert_raises(NameError) { controller.create }
+    events = captured_webhukhs_events do
+      raised_error = assert_raises(NameError) { controller.create }
 
-    assert_same original_error, raised_error
+      assert_same original_error, raised_error
+    end
+
+    assert_equal 1, events.size
+    event = events.fetch(0)
+    assert_equal :receive, event.fetch(:operation)
+    assert_equal :error, event.fetch(:outcome)
+    assert_equal :error, event.fetch(:severity)
+    assert_equal "broken", event.fetch(:service_id)
+    assert_same original_error, event.fetch(:error)
+    assert_false event.key?(:handler_class)
   end
 
   test "accepts handlers configured as class constants" do


### PR DESCRIPTION
fixes #15 

Refactors Webhukhs observability to emit a single ActiveSupport::Notifications event, **webhukhs.event**, instead of logging/reporting errors directly from the gem. 

Event Payload Schema
```
{
  operation: :receive | :process,
  outcome: :duplicate | :unknown_handler | :inactive_handler | :error |
           :discarded | :skipped | :started | :completed | :validation_failed,
  severity: :info | :warn | :error,
  error: Exception,          # only present for error events
  service_id: String,        # when available
  handler_class: String,     # when available
  handler_event_id: String,  # when available
  webhook_id: Integer | String # when available
}
```

Features:
- Initializer got updated with a proposed listener.
- README adjusted, to ensure that people will initialize gem correctly
- Configuration.error_context dropped