### PR TITLE
remove routing definition from engine

### DIFF
--- a/.yard-lint.yml
+++ b/.yard-lint.yml
@@ -11,6 +11,7 @@ AllValidators:
   # Global file exclusion patterns
   Exclude:
     - '\.git'
+    - 'lib/webhukhs/engine.rb'
     - 'vendor/**/*'
     - 'node_modules/**/*'
     - 'spec/**/*'

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Mount webhukhs engine in `config/routes.rb` file (simple approach, with only one
 mount Webhukhs::Engine, at: "/webhooks"
 ```
 
-Advanced mounting approach (all webhooks paths will shown in `rails routes`)
+Advanced mounting approach (all webhooks paths will be shown in `rails routes`)
 
 ```ruby
 Webhukhs.configuration.active_handlers.each_key do |service_id|

--- a/README.md
+++ b/README.md
@@ -19,10 +19,21 @@ Generate migrations and initializer file.
 
 `bin/rails g webhukhs:install`
 
-Mount webhukhs engine in your routes.
+Mount webhukhs engine in `config/routes.rb` file (simple approach, with only one dynamic route showing up in `rails routes`)
 
 ```ruby
 mount Webhukhs::Engine, at: "/webhooks"
+```
+
+Advanced mounting approach (all webhooks paths will shown in `rails routes`)
+
+```ruby
+Webhukhs.configuration.active_handlers.each_key do |service_id|
+  post "/webhooks/#{service_id}",
+    to: "webhukhs/receive_webhooks#create",
+    defaults: { service_id: service_id },
+    as: :"#{service_id.tr('-', '_')}_webhook"
+end
 ```
 
 Define a class for your first handler (let's call it `ExampleHandler`) and inherit it from `Webhukhs::BaseHandler`. We recommend `app/webhooks`, but any place known to autoloading will do.
@@ -63,7 +74,7 @@ Now you will be able to accept webhooks on `/webhooks/example` path.
 
 ## More Examples
 - `example` folder contains a demo app with engine fully configured.
-- We provide a number of webhook handlers which demonstrate certain features of Webhukhs. You will find them in `handler-examples`. 
+- We provide a number of webhook handlers which demonstrate certain features of Webhukhs. You will find them in `handler-examples`.
 
 ## Requirements
 

--- a/lib/webhukhs/engine.rb
+++ b/lib/webhukhs/engine.rb
@@ -17,9 +17,5 @@ module Webhukhs
     generators do
       require_relative "install_generator"
     end
-
-    routes do
-      post "/:service_id" => "received_webhooks#create"
-    end
   end
 end


### PR DESCRIPTION
We're asking users to define their own routes in config/routes.rb file. But our engine defines it's own routes as well.

This leads to double routes, e.g.

```bash
bin/rails routes -g service_id
To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
Routes for application:
Prefix Verb URI Pattern Controller#Action
   avo      /           Avo::Engine

Routes for Webhukhs::Engine:
Prefix Verb URI Pattern            Controller#Action
       POST /:service_id(.:format) webhukhs/receive_webhooks#create {namespace: "webhukhs"}
       POST /:service_id(.:format) webhukhs/received_webhooks#create
```

It's difficult to predict all possible use cases for routes. So we remove route definition from the engine and leave this up to users to define.


As a bonus, I'm also adding "advanced mounting" option to the readme. with this approach every possible webhook path is shown in `rails routes`. 
